### PR TITLE
Changed the heading size 

### DIFF
--- a/Bootstrap_task/bootstrap_online_shop.html
+++ b/Bootstrap_task/bootstrap_online_shop.html
@@ -33,7 +33,7 @@
 <body>
 <header class="header-container">
   <div class="heading-container">
-    <h25>One Stop Appliance Shop</h2> 
+    <h2>One Stop Appliance Shop</h2> <!--changed the heading size as there was an error in the code(<h25> instead of <h2>)-->
   </div>     
 </header>
 


### PR DESCRIPTION
# There was an error in the code. The heading was had an 'h25' tag on the left and an 'h2' on the right therefore the heading was not rendered correctly. I changed the 'h25' tag to an 'h2' tag and now it is displaying correctly.
